### PR TITLE
fix sha256 checksum file creation

### DIFF
--- a/modules/KIWIResult.pm
+++ b/modules/KIWIResult.pm
@@ -484,7 +484,7 @@ sub __sign_with_sha256sum {
         $kiwi -> failed ();
         return;
     }
-    while (my $entry = sort(readdir ($dh))) {
+    foreach my $entry (sort(readdir($dh))) {
         next if $entry eq "." || $entry eq "..";
         next if ! -f "$tmpdir/$entry";
         my $alg = 'sha256';


### PR DESCRIPTION
This got broken in commit 166cd36d0c79 ("Sort filesystem listings...")
Also fixes "Useless use of sort in scalar context..." runtime warning.